### PR TITLE
Added config for SWOT_L2_NALT_OGDR_NRTGPS_D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.0]
 
 ### Added
+ - Added config for SWOT_L2_NALT_OGDR_NRTGPS_D
+
+### Added
  - Added config for MERGED_TP_J1_OSTM_OST_CYCLES_V61, NASA_SSH_REF_ALONGTRACK_V11
 
 ### Added

--- a/config-files/SWOT_L2_NALT_OGDR_NRTGPS_D.cfg
+++ b/config-files/SWOT_L2_NALT_OGDR_NRTGPS_D.cfg
@@ -1,0 +1,25 @@
+{
+  "shortName": "SWOT_L2_NALT_OGDR_NRTGPS_D",
+  "latVar": "data_01/latitude",
+  "lonVar": "data_01/longitude",
+  "timeVar": "data_01/time",
+  "is360": true,
+  "tiles": {
+    "steps": [
+      30,
+      14
+    ]
+  },
+  "footprint": {
+    "strategy": "swot_linestring",
+    "t": "0:0,0:*",
+    "s1": "0:*,0:0",
+    "b": "*:*,0:*",
+    "s2": "0:*,*:*"
+  },
+  "imgVariables": [],
+  "image": {
+    "ppd": 16,
+    "res": 8
+  }
+}


### PR DESCRIPTION
Like SWOT_L2_NALT_OGDR_D, SWOT_L2_NALT_OGDR_NRTGPS_D should have footprinting but no thumbnails.